### PR TITLE
Add a Backend Library Description option for Settings

### DIFF
--- a/app/helpers/layouts/application_layout_helper.rb
+++ b/app/helpers/layouts/application_layout_helper.rb
@@ -135,6 +135,14 @@ module Layouts
 			return "Backend::#{name.titleize}".constantize.new settings
 		end
 
+		def backend_description name
+			unless File.exists? File.join(Rails.root,"lib","backend","#{name.downcase()}.rb")
+				return name
+			end
+			return "Backend::#{name.titleize}".constantize.description
+		end
+
+
 		def backends 
 			list = []
 			Settings.backends.each {|b|

--- a/app/views/partial/navbar/_settings_modal.html.erb
+++ b/app/views/partial/navbar/_settings_modal.html.erb
@@ -22,7 +22,7 @@
 
 		def display b, show_error=false 
 	%>
-		<tr><td colspan=2><%= b.type.titleize %> <%= "'"+b.alias+"'" if b.alias %></td></tr>
+		<tr><td colspan=2><%= backend_description b.type %> <%= "'"+b.alias+"'" if b.alias %></td></tr>
 		<% if b.description %>
 			<tr><td colspan=2><%= b.description %></td></tr>
 			<%end %>

--- a/lib/backend/generic_backend.rb
+++ b/lib/backend/generic_backend.rb
@@ -9,6 +9,7 @@ class Backend::GenericBackend
 		@params = params
 		@alias = optional_param :alias, name
 	end
+	def self.description; name.split("::").last; end
 
 	# Return an array of uniquely defined metrics
 	def get_metrics_list

--- a/lib/backend/sieste.rb
+++ b/lib/backend/sieste.rb
@@ -11,6 +11,8 @@ class Backend::Sieste < Backend::GenericBackend
 		@origin_alias   = optional_param :origin_alias, @alias
         end
 
+	def self.description; "Vaultaire"; end
+
 	# Sieste don't need no storage
         def get_metrics_list
 		raise Backend::Error, "Unable to connect to sieste instance at #{@base_url}" unless is_up? @base_url


### PR DESCRIPTION
Useful to be able to define something as being related to something as
opposed to it's library name (e.g. sieste <-> vaultaire)

Defaults to library name, but allows for library-based overloading

Doesn't require working settings, just a good title to call the right
backend description method. If it can't be found, it defaults to the
value given for "name".

This should be the smallest profile plumbing to get "Vaultaire"
displaying in place of Sieste on the settings modal
