### PR TITLE
Reintroduce nested library file structure

### DIFF
--- a/app/controllers/graphs_controller.rb
+++ b/app/controllers/graphs_controller.rb
@@ -81,7 +81,7 @@ class GraphsController < ApplicationController
 			Settings.origins.each do |o|
 				begin
 					origin, settings = o
-					store = Object.const_get(settings.store).new origin, settings
+					store = "Store::#{settings.store.titleize}".constantize.new origin, settings
 					store.refresh_metrics_cache
 				rescue Store::Error => e
 					inactive_backends << [o[0], e]

--- a/app/controllers/metrics_controller.rb
+++ b/app/controllers/metrics_controller.rb
@@ -51,7 +51,7 @@ class MetricsController < ApplicationController
 		b.each do |x|
 			begin
 				origin, settings = Settings.origins.find{|o,k| o.to_s == x}
-				be = (Object.const_get settings.store).new origin, settings
+				be = "Store::#{settings.store}".constantize.new origin, settings
 				ret = be.search_metrics(search, { page: page.to_i, page_size: page_size.to_i})
 				ret.each do |r| 
 					m = Metric.new r

--- a/app/views/graphs/horizon.html.erb
+++ b/app/views/graphs/horizon.html.erb
@@ -10,7 +10,7 @@
 <div id="clizia" style="position:relative; width: <%=width%>px"></div>
 
 <% def safe_array a; ("['"+a.join("','")+"']").html_safe; end
-colours = safe_array Horizon.get_colours
+colours = safe_array Graph::Horizon.get_colours
 %>
 
 <script>

--- a/lib/graph/graph.rb
+++ b/lib/graph/graph.rb
@@ -1,3 +1,3 @@
 # Graph class - this can be used for server-side ruby-action
-class Graph
+class Graph::Graph
 end

--- a/lib/graph/horizon.rb
+++ b/lib/graph/horizon.rb
@@ -1,7 +1,7 @@
 require 'color'
 
 # Horizon extension of Graph
-class Horizon < Graph
+class Graph::Horizon < Graph::Graph
 
 	# Default: Anchor blue
 	GRAPH_COLOUR = Settings.horizon_color || "#006d2c"

--- a/lib/metric.rb
+++ b/lib/metric.rb
@@ -8,8 +8,8 @@ class Metric
 		metric_id = get_id metric
 		@origin_id, @metric_id = metric_id.split(SEP)
 		@settings = origin_settings(@origin_id).last
-		@store = Object.const_get(@settings.store).new @origin_id, @settings
-		@source = Object.const_get(@settings.source).new @origin_id, @settings 
+		@store = "Store::#{@settings.store.titleize}".constantize.new @origin_id, @settings
+		@source = "Source::#{@settings.source.titleize}".constantize.new @origin_id, @settings 
 	end
 
 	# origin_id accessor function

--- a/lib/source/ceilometer.rb
+++ b/lib/source/ceilometer.rb
@@ -1,5 +1,5 @@
 # Collector: https://github.com/anchor/ceilometer-publisher-vaultaire
-class Ceilometer < Source
+class Source::Ceilometer < Source
 	include Helpers
 
 	# Take a metric metadata string, and return a human readable title
@@ -15,7 +15,7 @@ class Ceilometer < Source
 		if keys["counter_name"] then
 
 			# Create a Store object from the settings file to search metrics for us
-			store = (Object.const_get @settings.store).new @origin_id, @settings
+			store = "Store::#{@settings.store.titlize}".constantize.new @origin_id, @settings
 
 			if (keys["counter_name"].include? "network.") then
 				search = store.search_metrics "*memory*#{keys["instance_id"]}*"

--- a/lib/source/demowave.rb
+++ b/lib/source/demowave.rb
@@ -1,6 +1,6 @@
 # Collector: Demonstration Wave 
 # https://github.com/anchor/vaultaire/blob/master/src/DemoWave.hs
-class Demowave < Source
+class Source::Demowave < Source::Source
 
 	# Return a nice title no matter the input
 	def titleize str

--- a/lib/source/iptraffic.rb
+++ b/lib/source/iptraffic.rb
@@ -1,6 +1,6 @@
 # Generic IP Traffic Collector. i
 # Assumes sieste-style metadata in the form address, bytes: [tx,rx], collection_point: [datacenter], ip: [IPv4,IPv6]
-class Iptraffic < Source
+class Source::Iptraffic < Source::Source
 	include Helpers
 
 	# Use the useful parts of the metadata as the title

--- a/lib/source/nagios.rb
+++ b/lib/source/nagios.rb
@@ -1,5 +1,5 @@
 # Collector: https://github.com/anchor/vaultaire-collector-nagios
-class Nagios < Source
+class Source::Nagios < Source::Source
 	include Helpers
 
 	# Humanize the title for the perfdata feed. Handles both v1 and v2 style Vaultaire metadata

--- a/lib/source/source.rb
+++ b/lib/source/source.rb
@@ -1,6 +1,6 @@
 # Parent Collector Source class
 # Use this class directly when the source does not need any overrides
-class Source
+class Source::Source
 	def initialize origin_id, settings
 		@origin_id = origin_id
 		@settings = settings

--- a/lib/store/error.rb
+++ b/lib/store/error.rb
@@ -1,0 +1,2 @@
+class Store::Error < StandardError
+end;

--- a/lib/store/errorstore.rb
+++ b/lib/store/errorstore.rb
@@ -1,4 +1,4 @@
-class Errorstore < Store
+class Store::Errorstore < Store::Store
         def get_metric _,_,_,_
                 raise Store::Error, "Invalid origin: '#{@origin_id}' not defined in settings"
         end   

--- a/lib/store/flatfile.rb
+++ b/lib/store/flatfile.rb
@@ -1,5 +1,5 @@
 # Flatfile - ideally a CSV of `time,value\n`
-class Flatfile < Store
+class Store::Flatfile < Store::Store
 
 	# Initalize and get settings
 	def initialize origin, settings

--- a/lib/store/graphite.rb
+++ b/lib/store/graphite.rb
@@ -1,7 +1,7 @@
 require 'net/http'
 
 # Class for extracting data from Graphite (https://github.com/graphite-project/graphite-web)
-class Graphite < Store
+class Store::Graphite < Store::Store
 
 	def initialize origin,settings
 		super

--- a/lib/store/simple.rb
+++ b/lib/store/simple.rb
@@ -3,7 +3,7 @@
 # Assumes an endpoint for a list of metrics, and an endpoint to request data for a specific metric
 #
 # This class can be used as a template for development of any custom classes to leverage JSON feeds of metrics
-class Simple < Store
+class Store::Simple < Store::Store
         def initialize origin, settings
 		super 
                 @base_url = mandatory_param :url, "store_settings"

--- a/lib/store/store.rb
+++ b/lib/store/store.rb
@@ -1,5 +1,5 @@
 # Parent Store class. Contains mostly defaults
-class Store
+class Store::Store
 	include Helpers
 
 	# Store given settings into more user friendly forms

--- a/lib/store/vaultaire.rb
+++ b/lib/store/vaultaire.rb
@@ -1,5 +1,5 @@
 # Storage for Vaultaire TSDB (https://github.com/anchor/vaultaire) via it's RESTful backend (https://github.com/anchor/sieste)
-class Vaultaire < Store
+class Store::Vaultaire < Store::Store
 	include Helpers
 
 	def initialize origin, settings


### PR DESCRIPTION
To have a nested folder structure, rails requires the library file names be nested, and their class names also. That is, lib/class/child.rb must be called Class::Child.

This commit reintroduces this, and changes all dynamic requirements to the old format, leveraging 'constantize'.
