### PR TITLE
Clizia requires static y2axis node. Use right_axis css for formatting

### DIFF
--- a/app/views/graphs/stacked.html.erb
+++ b/app/views/graphs/stacked.html.erb
@@ -10,7 +10,9 @@
 <div class="slider" id="slider"></div>
 <span id="zoomtoselected" class="no_link zoomtoselected"></span>
 
-<div id="chart"></div>
+<div id="chart">
+<div class="y_axis right_axis" id="y_axis_right"></div>
+</div>
 <div class="legend" id="legend-dual"></div>
 
 <script>


### PR DESCRIPTION
Addresses issue #52 

only left-axis is autogenerated by clizia. still need to have sufficient existence and formatting for right-yaxis to function. 
