### PR TITLE
Enable suppression of specific settings elements

### DIFF
--- a/app/helpers/layouts/application_layout_helper.rb
+++ b/app/helpers/layouts/application_layout_helper.rb
@@ -245,5 +245,11 @@ module Layouts
 				end )
 			eval("#{mult}.#{time_scale}.ago.to_i")
 		end
+
+		def settings_suppress settings
+			mock_origin = "ABC"
+			store = "Store::#{settings.store.titleize}".constantize.new mock_origin, settings
+			return store.supress_settings
+		end
 	end
 end

--- a/app/views/partial/navbar/_settings_modal.html.erb
+++ b/app/views/partial/navbar/_settings_modal.html.erb
@@ -26,11 +26,9 @@
 	       	%>
 			<tr <%="class=alert-danger" if m%>>
 				<%[id,settings.title,settings.store,settings.source].each{|s| td s}%>
-			<% settings.sort.each do |k,v| 
-				unless v.is_a? String then
-				%><%td v.map{|a,b| "#{a}: #{b}"}.join("<br>")%>
-			<%      end
-			end%></tr>
+			<% s = settings_suppress(settings);
+			   td s.sort.map{ |k,v| "#{k}: #{v}"}.join("<br/>")
+			%></tr>
 			<% if m then %>
 				<tr <%="class=alert-danger" if m%>><td> - Error Encountered:</td><td colspan=4><%= m %></td></tr>
 			<% end %>

--- a/lib/store/store.rb
+++ b/lib/store/store.rb
@@ -67,6 +67,20 @@ class Store::Store
                 keys
         end
 
+	# A list of store settings keys that should NEVER have their settings written out to the interface.
+	def hidden_keys
+		["password"]
+	end
+
+	# When parsing the settings file for the settings modal, suppress certain information
+	def supress_settings
+		hide = hidden_keys.map{|k| k.to_sym}
+		sett = @settings.store_settings.to_a.map do |k,v|
+			v = "*********" if hide.include? k
+			[k,v]
+		end
+		sett
+	end
 end
 
 # Stores have the own errors!


### PR DESCRIPTION
When parsing the settings for the settings modal, pass through a sanity check to suppress certain values, if required.

For example, do not display passwords in the settings modal, by default.

To extend, add a function in your Store library:
`
  def hidden_keys
    super.concat(["key1","key2"])
    # super.push("key3")
  end
`
