### PR TITLE
Correct popstate history re-write logic

### DIFF
--- a/app/assets/javascripts/util.js
+++ b/app/assets/javascripts/util.js
@@ -28,8 +28,10 @@ function general_removechart(metric,newurl,length) {
 
 // On back button popstate, reload the page. Uses history alterations, but actually invokes them
 $(window).bind('popstate', function(event){
-	if (event.originalEvent.state.style === "removechart") {
-		window.location = location.href
+	if (!(event.originalEvent.state === null)) {
+		if (event.originalEvent.state.style === "removechart") {
+			window.location = location.href
+		}
 	}
 })
 


### PR DESCRIPTION
Errors were occuring when using the slider with the popstate function, besauce event.OriginalEvent.state was null, which was erroring as it doesn't have a properly 'style'.

Add an additional check to confirm object exists before checking it's contents.

Works with remove-graph, back-button usecase, and slider resizing.
